### PR TITLE
Add support for non grid source type (Gas, Water, Return to Grid)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,14 +48,15 @@ The main difference is the addition of `price` and `price_entity` options:
 
 **price** _float (optional)_
 
-The static price of the tariff (in currency/kWh)
+The static price of the tariff (in currency per source unit, e.g. USD/kWh or
+USD/m³)
 
 ---
 
 **price_entity** _string (optional)_
 
-The entity ID of a sensor giving the current price of the tariff (in
-currency/kWh)
+The entity ID of a sensor giving the current price of the tariff (in currency
+per source unit, e.g. USD/kWh or USD/m³)
 
 ---
 
@@ -66,6 +67,30 @@ in $/kWh.
 Only one of `price` or `price_entity` should be given. If both are given,
 `price_entity` would have precedence. If none is defined, this integration will
 act as a basic utility meter, with no cost tracking.
+
+### Energy cost type (Gas, Water, Return to grid)
+
+The configuration can contain the optional `source_type` option to define the
+type of energy being monitored:
+
+---
+
+**source_type** _string (optional)_
+
+The type of energy being followed as source. These are the same as the builtin
+energy dashboard. It can be of 4 types:
+
+- `from_grid`: this is the default. To be used if source tracks grid
+  consumption.
+- `to_grid`: to be used if source tracks energy returned to grid.
+- `gas`: to be used if source tracks gas consumption.
+- `water`: to be used if source tracks water consumption.
+
+---
+
+Keep in mind that depending on the time, the allowed units for the source will
+differ. `from_grid` and `to_grid` needs an electrical energy, while `gas` and
+`water` expect a volume.
 
 ### Energy cost sensor only
 
@@ -108,6 +133,16 @@ energy_meter:
     source: sensor.energy
     price: 0.20
     create_utility_meter: false
+
+  monthly_gas:
+    source: sensor.gas_consumption
+    name: Monthly Gas
+    cycle: monthly
+    price_entity: sensor.current_gas_price
+    source_type: gas
+    tariffs:
+      - peak
+      - offpeak
 ```
 
 Usually, source energy sensors shares the same price. In order to prevent

--- a/custom_components/energy_meter/const.py
+++ b/custom_components/energy_meter/const.py
@@ -3,9 +3,11 @@
 DOMAIN = "energy_meter"
 
 CONF_CONF = "conf"
+CONF_ADAPTER = "adapter"
 
 CONF_PRICE = "price"
 CONF_PRICE_ENTITY = "price_entity"
 CONF_UTILITY_METER = "create_utility_meter"
+CONF_SOURCE_TYPE = "source_type"
 
 DATA_ENERGY_METER = "energy_meter_data"

--- a/custom_components/energy_meter/sensor.py
+++ b/custom_components/energy_meter/sensor.py
@@ -18,7 +18,13 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from .const import CONF_ADAPTER, CONF_CONF, CONF_PRICE, CONF_PRICE_ENTITY
+from .const import (
+    CONF_ADAPTER,
+    CONF_CONF,
+    CONF_PRICE,
+    CONF_PRICE_ENTITY,
+    DOMAIN,
+)
 from .utils import conf_to_cost_sensor_id
 
 _LOGGER = logging.getLogger(__name__)
@@ -33,8 +39,9 @@ async def async_setup_platform(
     """Set up the cost sensor."""
     if discovery_info is None:
         _LOGGER.error(
-            "This platform is not available to configure "
+            "Setup %s: This platform is not available to configure "
             "from 'sensor:' in configuration.yaml",
+            DOMAIN,
         )
         return
 

--- a/tests/const.py
+++ b/tests/const.py
@@ -322,6 +322,53 @@ TEST_CASES = [
             },
         },
     },
+    ################################
+    # Create utility meter defined #
+    ################################
+    # No price 2 tariffs
+    {
+        DOMAIN: {
+            "daily_energy": {
+                "source": "sensor.energy",
+                "tariffs": ["peak", "offpeak"],
+                "create_utility_meter": "yes",
+            },
+        },
+    },
+    # Price entity 2 tariffs
+    {
+        DOMAIN: {
+            "daily_energy": {
+                "source": "sensor.energy",
+                "price_entity": "sensor.price",
+                "tariffs": ["peak", "offpeak"],
+                "create_utility_meter": "yes",
+            },
+        },
+    },
+    # Fixed price 2 tariffs
+    {
+        DOMAIN: {
+            "daily_energy": {
+                "source": "sensor.energy",
+                "price": 2,
+                "tariffs": ["peak", "offpeak"],
+                "create_utility_meter": "yes",
+            },
+        },
+    },
+    # Price entity & fixed price 2 tariffs
+    {
+        DOMAIN: {
+            "daily_energy": {
+                "source": "sensor.energy",
+                "price_entity": "sensor.price",
+                "price": 2,
+                "tariffs": ["peak", "offpeak"],
+                "create_utility_meter": "yes",
+            },
+        },
+    },
     ##################################
     # Create only Energy cost sensor #
     ##################################
@@ -406,6 +453,194 @@ TEST_CASES = [
                 "price": 2,
                 "tariffs": ["peak", "offpeak"],
                 "create_utility_meter": "no",
+            },
+        },
+    },
+    #########################
+    # from_grid source_type #
+    #########################
+    # No price 2 tariffs
+    {
+        DOMAIN: {
+            "daily_energy": {
+                "source": "sensor.energy",
+                "tariffs": ["peak", "offpeak"],
+                "source_type": "from_grid",
+            },
+        },
+    },
+    # Price entity 2 tariffs
+    {
+        DOMAIN: {
+            "daily_energy": {
+                "source": "sensor.energy",
+                "price_entity": "sensor.price",
+                "tariffs": ["peak", "offpeak"],
+                "source_type": "from_grid",
+            },
+        },
+    },
+    # Fixed price 2 tariffs
+    {
+        DOMAIN: {
+            "daily_energy": {
+                "source": "sensor.energy",
+                "price": 2,
+                "tariffs": ["peak", "offpeak"],
+                "source_type": "from_grid",
+            },
+        },
+    },
+    # Price entity & fixed price 2 tariffs
+    {
+        DOMAIN: {
+            "daily_energy": {
+                "source": "sensor.energy",
+                "price_entity": "sensor.price",
+                "price": 2,
+                "tariffs": ["peak", "offpeak"],
+                "source_type": "from_grid",
+            },
+        },
+    },
+    #######################
+    # to_grid source_type #
+    #######################
+    # No price 2 tariffs
+    {
+        DOMAIN: {
+            "daily_energy": {
+                "source": "sensor.energy",
+                "tariffs": ["peak", "offpeak"],
+                "source_type": "to_grid",
+            },
+        },
+    },
+    # Price entity 2 tariffs
+    {
+        DOMAIN: {
+            "daily_energy": {
+                "source": "sensor.energy",
+                "price_entity": "sensor.price",
+                "tariffs": ["peak", "offpeak"],
+                "source_type": "to_grid",
+            },
+        },
+    },
+    # Fixed price 2 tariffs
+    {
+        DOMAIN: {
+            "daily_energy": {
+                "source": "sensor.energy",
+                "price": 2,
+                "tariffs": ["peak", "offpeak"],
+                "source_type": "to_grid",
+            },
+        },
+    },
+    # Price entity & fixed price 2 tariffs
+    {
+        DOMAIN: {
+            "daily_energy": {
+                "source": "sensor.energy",
+                "price_entity": "sensor.price",
+                "price": 2,
+                "tariffs": ["peak", "offpeak"],
+                "source_type": "to_grid",
+            },
+        },
+    },
+    ###################
+    # gas source_type #
+    ###################
+    # No price 2 tariffs
+    {
+        DOMAIN: {
+            "daily_energy": {
+                "source": "sensor.energy",
+                "tariffs": ["peak", "offpeak"],
+                "source_type": "gas",
+            },
+        },
+    },
+    # Price entity 2 tariffs
+    {
+        DOMAIN: {
+            "daily_energy": {
+                "source": "sensor.energy",
+                "price_entity": "sensor.price",
+                "tariffs": ["peak", "offpeak"],
+                "source_type": "gas",
+            },
+        },
+    },
+    # Fixed price 2 tariffs
+    {
+        DOMAIN: {
+            "daily_energy": {
+                "source": "sensor.energy",
+                "price": 2,
+                "tariffs": ["peak", "offpeak"],
+                "source_type": "gas",
+            },
+        },
+    },
+    # Price entity & fixed price 2 tariffs
+    {
+        DOMAIN: {
+            "daily_energy": {
+                "source": "sensor.energy",
+                "price_entity": "sensor.price",
+                "price": 2,
+                "tariffs": ["peak", "offpeak"],
+                "source_type": "gas",
+            },
+        },
+    },
+    #####################
+    # water source_type #
+    #####################
+    # No price 2 tariffs
+    {
+        DOMAIN: {
+            "daily_energy": {
+                "source": "sensor.energy",
+                "tariffs": ["peak", "offpeak"],
+                "source_type": "water",
+            },
+        },
+    },
+    # Price entity 2 tariffs
+    {
+        DOMAIN: {
+            "daily_energy": {
+                "source": "sensor.energy",
+                "price_entity": "sensor.price",
+                "tariffs": ["peak", "offpeak"],
+                "source_type": "water",
+            },
+        },
+    },
+    # Fixed price 2 tariffs
+    {
+        DOMAIN: {
+            "daily_energy": {
+                "source": "sensor.energy",
+                "price": 2,
+                "tariffs": ["peak", "offpeak"],
+                "source_type": "water",
+            },
+        },
+    },
+    # Price entity & fixed price 2 tariffs
+    {
+        DOMAIN: {
+            "daily_energy": {
+                "source": "sensor.energy",
+                "price_entity": "sensor.price",
+                "price": 2,
+                "tariffs": ["peak", "offpeak"],
+                "source_type": "water",
             },
         },
     },
@@ -658,6 +893,42 @@ CHECK_CREATED_EXPECTED_RESULTS = [
         "sensor.daily_energy_cost_offpeak",
         "select.daily_energy",
     ],
+    ################################
+    # Create utility meter defined #
+    ################################
+    # No price 2 tariffs
+    [
+        "sensor.daily_energy_peak",
+        "sensor.daily_energy_offpeak",
+        "select.daily_energy",
+    ],
+    # Price entity 2 tariffs
+    [
+        "sensor.energy_price_cost",
+        "sensor.daily_energy_peak",
+        "sensor.daily_energy_offpeak",
+        "sensor.daily_energy_cost_peak",
+        "sensor.daily_energy_cost_offpeak",
+        "select.daily_energy",
+    ],
+    # Fixed price 2 tariffs
+    [
+        "sensor.energy_daily_energy_cost",
+        "sensor.daily_energy_peak",
+        "sensor.daily_energy_offpeak",
+        "sensor.daily_energy_cost_peak",
+        "sensor.daily_energy_cost_offpeak",
+        "select.daily_energy",
+    ],
+    # Price entity & fixed price 2 tariffs
+    [
+        "sensor.energy_price_cost",
+        "sensor.daily_energy_peak",
+        "sensor.daily_energy_offpeak",
+        "sensor.daily_energy_cost_peak",
+        "sensor.daily_energy_cost_offpeak",
+        "select.daily_energy",
+    ],
     ##################################
     # Create only Energy cost sensor #
     ##################################
@@ -688,6 +959,150 @@ CHECK_CREATED_EXPECTED_RESULTS = [
     # Price entity & fixed price 2 tariffs
     [
         "sensor.energy_price_cost",
+    ],
+    #########################
+    # from_grid source_type #
+    #########################
+    # No price 2 tariffs
+    [
+        "sensor.daily_energy_peak",
+        "sensor.daily_energy_offpeak",
+        "select.daily_energy",
+    ],
+    # Price entity 2 tariffs
+    [
+        "sensor.energy_price_cost",
+        "sensor.daily_energy_peak",
+        "sensor.daily_energy_offpeak",
+        "sensor.daily_energy_cost_peak",
+        "sensor.daily_energy_cost_offpeak",
+        "select.daily_energy",
+    ],
+    # Fixed price 2 tariffs
+    [
+        "sensor.energy_daily_energy_cost",
+        "sensor.daily_energy_peak",
+        "sensor.daily_energy_offpeak",
+        "sensor.daily_energy_cost_peak",
+        "sensor.daily_energy_cost_offpeak",
+        "select.daily_energy",
+    ],
+    # Price entity & fixed price 2 tariffs
+    [
+        "sensor.energy_price_cost",
+        "sensor.daily_energy_peak",
+        "sensor.daily_energy_offpeak",
+        "sensor.daily_energy_cost_peak",
+        "sensor.daily_energy_cost_offpeak",
+        "select.daily_energy",
+    ],
+    #######################
+    # to_grid source_type #
+    #######################
+    # No price 2 tariffs
+    [
+        "sensor.daily_energy_peak",
+        "sensor.daily_energy_offpeak",
+        "select.daily_energy",
+    ],
+    # Price entity 2 tariffs
+    [
+        "sensor.energy_price_compensation",
+        "sensor.daily_energy_peak",
+        "sensor.daily_energy_offpeak",
+        "sensor.daily_energy_compensation_peak",
+        "sensor.daily_energy_compensation_offpeak",
+        "select.daily_energy",
+    ],
+    # Fixed price 2 tariffs
+    [
+        "sensor.energy_daily_energy_compensation",
+        "sensor.daily_energy_peak",
+        "sensor.daily_energy_offpeak",
+        "sensor.daily_energy_compensation_peak",
+        "sensor.daily_energy_compensation_offpeak",
+        "select.daily_energy",
+    ],
+    # Price entity & fixed price 2 tariffs
+    [
+        "sensor.energy_price_compensation",
+        "sensor.daily_energy_peak",
+        "sensor.daily_energy_offpeak",
+        "sensor.daily_energy_compensation_peak",
+        "sensor.daily_energy_compensation_offpeak",
+        "select.daily_energy",
+    ],
+    ###################
+    # gas source_type #
+    ###################
+    # No price 2 tariffs
+    [
+        "sensor.daily_energy_peak",
+        "sensor.daily_energy_offpeak",
+        "select.daily_energy",
+    ],
+    # Price entity 2 tariffs
+    [
+        "sensor.energy_price_cost",
+        "sensor.daily_energy_peak",
+        "sensor.daily_energy_offpeak",
+        "sensor.daily_energy_cost_peak",
+        "sensor.daily_energy_cost_offpeak",
+        "select.daily_energy",
+    ],
+    # Fixed price 2 tariffs
+    [
+        "sensor.energy_daily_energy_cost",
+        "sensor.daily_energy_peak",
+        "sensor.daily_energy_offpeak",
+        "sensor.daily_energy_cost_peak",
+        "sensor.daily_energy_cost_offpeak",
+        "select.daily_energy",
+    ],
+    # Price entity & fixed price 2 tariffs
+    [
+        "sensor.energy_price_cost",
+        "sensor.daily_energy_peak",
+        "sensor.daily_energy_offpeak",
+        "sensor.daily_energy_cost_peak",
+        "sensor.daily_energy_cost_offpeak",
+        "select.daily_energy",
+    ],
+    #####################
+    # water source_type #
+    #####################
+    # No price 2 tariffs
+    [
+        "sensor.daily_energy_peak",
+        "sensor.daily_energy_offpeak",
+        "select.daily_energy",
+    ],
+    # Price entity 2 tariffs
+    [
+        "sensor.energy_price_cost",
+        "sensor.daily_energy_peak",
+        "sensor.daily_energy_offpeak",
+        "sensor.daily_energy_cost_peak",
+        "sensor.daily_energy_cost_offpeak",
+        "select.daily_energy",
+    ],
+    # Fixed price 2 tariffs
+    [
+        "sensor.energy_daily_energy_cost",
+        "sensor.daily_energy_peak",
+        "sensor.daily_energy_offpeak",
+        "sensor.daily_energy_cost_peak",
+        "sensor.daily_energy_cost_offpeak",
+        "select.daily_energy",
+    ],
+    # Price entity & fixed price 2 tariffs
+    [
+        "sensor.energy_price_cost",
+        "sensor.daily_energy_peak",
+        "sensor.daily_energy_offpeak",
+        "sensor.daily_energy_cost_peak",
+        "sensor.daily_energy_cost_offpeak",
+        "select.daily_energy",
     ],
 ]
 
@@ -889,6 +1304,35 @@ CHECK_UM_SOURCES_EXPECTED_RESULTS = [
         "sensor.daily_energy_cost_peak": "sensor.energy_price_cost",
         "sensor.daily_energy_cost_offpeak": "sensor.energy_price_cost",
     },
+    ################################
+    # Create utility meter defined #
+    ################################
+    # No price 2 tariffs
+    {
+        "sensor.daily_energy_peak": "sensor.energy",
+        "sensor.daily_energy_offpeak": "sensor.energy",
+    },
+    # Price entity 2 tariffs
+    {
+        "sensor.daily_energy_peak": "sensor.energy",
+        "sensor.daily_energy_offpeak": "sensor.energy",
+        "sensor.daily_energy_cost_peak": "sensor.energy_price_cost",
+        "sensor.daily_energy_cost_offpeak": "sensor.energy_price_cost",
+    },
+    # Fixed price 2 tariffs
+    {
+        "sensor.daily_energy_peak": "sensor.energy",
+        "sensor.daily_energy_offpeak": "sensor.energy",
+        "sensor.daily_energy_cost_peak": "sensor.energy_daily_energy_cost",
+        "sensor.daily_energy_cost_offpeak": "sensor.energy_daily_energy_cost",
+    },
+    # Price entity & fixed price 2 tariffs
+    {
+        "sensor.daily_energy_peak": "sensor.energy",
+        "sensor.daily_energy_offpeak": "sensor.energy",
+        "sensor.daily_energy_cost_peak": "sensor.energy_price_cost",
+        "sensor.daily_energy_cost_offpeak": "sensor.energy_price_cost",
+    },
     ##################################
     # Create only Energy cost sensor #
     ##################################
@@ -909,4 +1353,149 @@ CHECK_UM_SOURCES_EXPECTED_RESULTS = [
     {},
     # Price entity & fixed price 2 tariffs
     {},
+    #########################
+    # from_grid source_type #
+    #########################
+    # No price 2 tariffs
+    {
+        "sensor.daily_energy_peak": "sensor.energy",
+        "sensor.daily_energy_offpeak": "sensor.energy",
+    },
+    # Price entity 2 tariffs
+    {
+        "sensor.daily_energy_peak": "sensor.energy",
+        "sensor.daily_energy_offpeak": "sensor.energy",
+        "sensor.daily_energy_cost_peak": "sensor.energy_price_cost",
+        "sensor.daily_energy_cost_offpeak": "sensor.energy_price_cost",
+    },
+    # Fixed price 2 tariffs
+    {
+        "sensor.daily_energy_peak": "sensor.energy",
+        "sensor.daily_energy_offpeak": "sensor.energy",
+        "sensor.daily_energy_cost_peak": "sensor.energy_daily_energy_cost",
+        "sensor.daily_energy_cost_offpeak": "sensor.energy_daily_energy_cost",
+    },
+    # Price entity & fixed price 2 tariffs
+    {
+        "sensor.daily_energy_peak": "sensor.energy",
+        "sensor.daily_energy_offpeak": "sensor.energy",
+        "sensor.daily_energy_cost_peak": "sensor.energy_price_cost",
+        "sensor.daily_energy_cost_offpeak": "sensor.energy_price_cost",
+    },
+    #######################
+    # to_grid source_type #
+    #######################
+    # No price 2 tariffs
+    {
+        "sensor.daily_energy_peak": "sensor.energy",
+        "sensor.daily_energy_offpeak": "sensor.energy",
+    },
+    # Price entity 2 tariffs
+    {
+        "sensor.daily_energy_peak": "sensor.energy",
+        "sensor.daily_energy_offpeak": "sensor.energy",
+        "sensor.daily_energy_compensation_peak": "sensor.energy_price_compensation",
+        "sensor.daily_energy_compensation_offpeak": "sensor.energy_price_compensation",
+    },
+    # Fixed price 2 tariffs
+    {
+        "sensor.daily_energy_peak": "sensor.energy",
+        "sensor.daily_energy_offpeak": "sensor.energy",
+        "sensor.daily_energy_compensation_peak": "sensor.energy_daily_energy_compensation",
+        "sensor.daily_energy_compensation_offpeak": "sensor.energy_daily_energy_compensation",
+    },
+    # Price entity & fixed price 2 tariffs
+    {
+        "sensor.daily_energy_peak": "sensor.energy",
+        "sensor.daily_energy_offpeak": "sensor.energy",
+        "sensor.daily_energy_compensation_peak": "sensor.energy_price_compensation",
+        "sensor.daily_energy_compensation_offpeak": "sensor.energy_price_compensation",
+    },
+    ###################
+    # gas source_type #
+    ###################
+    # No price 2 tariffs
+    {
+        "sensor.daily_energy_peak": "sensor.energy",
+        "sensor.daily_energy_offpeak": "sensor.energy",
+    },
+    # Price entity 2 tariffs
+    {
+        "sensor.daily_energy_peak": "sensor.energy",
+        "sensor.daily_energy_offpeak": "sensor.energy",
+        "sensor.daily_energy_cost_peak": "sensor.energy_price_cost",
+        "sensor.daily_energy_cost_offpeak": "sensor.energy_price_cost",
+    },
+    # Fixed price 2 tariffs
+    {
+        "sensor.daily_energy_peak": "sensor.energy",
+        "sensor.daily_energy_offpeak": "sensor.energy",
+        "sensor.daily_energy_cost_peak": "sensor.energy_daily_energy_cost",
+        "sensor.daily_energy_cost_offpeak": "sensor.energy_daily_energy_cost",
+    },
+    # Price entity & fixed price 2 tariffs
+    {
+        "sensor.daily_energy_peak": "sensor.energy",
+        "sensor.daily_energy_offpeak": "sensor.energy",
+        "sensor.daily_energy_cost_peak": "sensor.energy_price_cost",
+        "sensor.daily_energy_cost_offpeak": "sensor.energy_price_cost",
+    },
+    #####################
+    # water source_type #
+    #####################
+    # No price 2 tariffs
+    {
+        "sensor.daily_energy_peak": "sensor.energy",
+        "sensor.daily_energy_offpeak": "sensor.energy",
+    },
+    # Price entity 2 tariffs
+    {
+        "sensor.daily_energy_peak": "sensor.energy",
+        "sensor.daily_energy_offpeak": "sensor.energy",
+        "sensor.daily_energy_cost_peak": "sensor.energy_price_cost",
+        "sensor.daily_energy_cost_offpeak": "sensor.energy_price_cost",
+    },
+    # Fixed price 2 tariffs
+    {
+        "sensor.daily_energy_peak": "sensor.energy",
+        "sensor.daily_energy_offpeak": "sensor.energy",
+        "sensor.daily_energy_cost_peak": "sensor.energy_daily_energy_cost",
+        "sensor.daily_energy_cost_offpeak": "sensor.energy_daily_energy_cost",
+    },
+    # Price entity & fixed price 2 tariffs
+    {
+        "sensor.daily_energy_peak": "sensor.energy",
+        "sensor.daily_energy_offpeak": "sensor.energy",
+        "sensor.daily_energy_cost_peak": "sensor.energy_price_cost",
+        "sensor.daily_energy_cost_offpeak": "sensor.energy_price_cost",
+    },
+    #########################
+    # from_grid source_type #
+    #########################
+    # No price 2 tariffs
+    {
+        "sensor.daily_energy_peak": "sensor.energy",
+        "sensor.daily_energy_offpeak": "sensor.energy",
+    },
+    # Price entity 2 tariffs
+    {
+        "sensor.daily_energy_peak": "sensor.energy",
+        "sensor.daily_energy_offpeak": "sensor.energy",
+        "sensor.daily_energy_cost_peak": "sensor.energy_price_cost",
+        "sensor.daily_energy_cost_offpeak": "sensor.energy_price_cost",
+    },
+    # Fixed price 2 tariffs
+    {
+        "sensor.daily_energy_peak": "sensor.energy",
+        "sensor.daily_energy_offpeak": "sensor.energy",
+        "sensor.daily_energy_cost_peak": "sensor.energy_daily_energy_cost",
+        "sensor.daily_energy_cost_offpeak": "sensor.energy_daily_energy_cost",
+    },
+    # Price entity & fixed price 2 tariffs
+    {
+        "sensor.daily_energy_peak": "sensor.energy",
+        "sensor.daily_energy_offpeak": "sensor.energy",
+        "sensor.daily_energy_cost_peak": "sensor.energy_price_cost",
+        "sensor.daily_energy_cost_offpeak": "sensor.energy_price_cost",
+    },
 ]

--- a/tests/server/includes/dashboard.yaml
+++ b/tests/server/includes/dashboard.yaml
@@ -25,13 +25,6 @@ views:
               service: utility_meter.reset
               target:
                 entity_id: select.monthly_energy
-          - type: button
-            name: Reset yearly meter
-            tap_action:
-              action: call-service
-              service: utility_meter.reset
-              target:
-                entity_id: select.yearly_energy
 
       - type: entities
         entities:
@@ -43,6 +36,7 @@ views:
           - type: section
           - sensor.energy_energy_price_cost
           - sensor.energy2_energy_price2_cost
+          - sensor.energy2_energy_price2_compensation
           - type: section
           - sensor.daily_energy_peak
           - sensor.daily_energy_offpeak
@@ -56,3 +50,100 @@ views:
           - type: section
           - sensor.yearly_energy
           - sensor.yearly_energy_cost
+          - type: section
+          - sensor.daily_energy_to_grid_peak
+          - sensor.daily_energy_to_grid_offpeak
+          - sensor.daily_energy_to_grid_compensation_peak
+          - sensor.daily_energy_to_grid_compensation_offpeak
+
+  - title: Gas
+    path: gas
+    cards:
+      - type: entities
+        entities:
+          - input_number.gas_price
+          - input_number.gas_flow
+          - type: section
+          - select.daily_gas
+          - select.monthly_gas
+          - type: button
+            name: Reset daily meter
+            tap_action:
+              action: call-service
+              service: utility_meter.reset
+              target:
+                entity_id: select.daily_gas
+          - type: button
+            name: Reset monthly meter
+            tap_action:
+              action: call-service
+              service: utility_meter.reset
+              target:
+                entity_id: select.monthly_gas
+
+      - type: entities
+        entities:
+          - sensor.gas_price
+          - sensor.gas_flow
+          - sensor.gas
+          - type: section
+          - sensor.gas_gas_price_cost
+          - type: section
+          - sensor.daily_gas_peak
+          - sensor.daily_gas_offpeak
+          - sensor.daily_gas_cost_peak
+          - sensor.daily_gas_cost_offpeak
+          - type: section
+          - sensor.monthly_gas_peak
+          - sensor.monthly_gas_offpeak
+          - sensor.monthly_gas_cost_peak
+          - sensor.monthly_gas_cost_offpeak
+          - type: section
+          - sensor.yearly_gas
+          - sensor.yearly_gas_cost
+
+  - title: Water
+    path: water
+    cards:
+      - type: entities
+        entities:
+          - input_number.water_price
+          - input_number.water_flow
+          - type: section
+          - select.daily_water
+          - select.monthly_water
+          - type: button
+            name: Reset daily meter
+            tap_action:
+              action: call-service
+              service: utility_meter.reset
+              target:
+                entity_id: select.daily_water
+          - type: button
+            name: Reset monthly meter
+            tap_action:
+              action: call-service
+              service: utility_meter.reset
+              target:
+                entity_id: select.monthly_water
+
+      - type: entities
+        entities:
+          - sensor.water_price
+          - sensor.water_flow
+          - sensor.water
+          - type: section
+          - sensor.water_water_price_cost
+          - type: section
+          - sensor.daily_water_peak
+          - sensor.daily_water_offpeak
+          - sensor.daily_water_cost_peak
+          - sensor.daily_water_cost_offpeak
+          - type: section
+          - sensor.monthly_water_peak
+          - sensor.monthly_water_offpeak
+          - sensor.monthly_water_cost_peak
+          - sensor.monthly_water_cost_offpeak
+          - type: section
+          - sensor.yearly_water
+          - sensor.yearly_water_cost

--- a/tests/server/includes/package.yaml
+++ b/tests/server/includes/package.yaml
@@ -11,12 +11,36 @@ input_number:
     min: 0
     max: 100
     step: 0.5
+  gas_price:
+    name: Gas price input
+    initial: 2
+    min: 0
+    max: 100
+    step: 0.5
+  water_price:
+    name: Water price input
+    initial: 2
+    min: 0
+    max: 100
+    step: 0.5
   power:
     name: Power input
     initial: 1000
     min: 0
     max: 10000
     step: 100
+  gas_flow:
+    name: Gas Flow input
+    initial: 3
+    min: 0
+    max: 100
+    step: 0.5
+  water_flow:
+    name: Water Flow input
+    initial: 3
+    min: 0
+    max: 100
+    step: 0.5
 
 template:
   - trigger:
@@ -37,12 +61,44 @@ template:
         device_class: monetary
         attributes: # to force update every seconds for integration
           attribute: "{{ now().second }}"
+      - name: Gas price
+        state: "{{ states('input_number.gas_price') }}"
+        unit_of_measurement: USD/m³
+        device_class: monetary
+        attributes: # to force update every seconds for integration
+          attribute: "{{ now().second }}"
+      - name: Water price
+        state: "{{ states('input_number.water_price') }}"
+        unit_of_measurement: USD/m³
+        device_class: monetary
+        attributes: # to force update every seconds for integration
+          attribute: "{{ now().second }}"
       - name: Power
         state: "{{ states('input_number.power') }}"
         unit_of_measurement: W
         device_class: power
         attributes: # to force update every seconds for integration
           attribute: "{{ now().second }}"
+      - name: Gas Flow
+        state: "{{ states('input_number.gas_flow') }}"
+        unit_of_measurement: m³/s
+        attributes: # to force update every seconds for integration
+          attribute: "{{ now().second }}"
+      - name: Gas
+        state: "{{ states('sensor.gas_int') }}"
+        device_class: gas
+        state_class: total_increasing
+        unit_of_measurement: m³
+      - name: Water Flow
+        state: "{{ states('input_number.water_flow') }}"
+        unit_of_measurement: m³/s
+        attributes: # to force update every seconds for integration
+          attribute: "{{ now().second }}"
+      - name: Water
+        state: "{{ states('sensor.water_int') }}"
+        state_class: total_increasing
+        device_class: water
+        unit_of_measurement: m³
 
 sensor:
   - platform: integration
@@ -53,6 +109,14 @@ sensor:
     source: sensor.power
     name: energy2
     unit_prefix: k
+  - platform: integration
+    source: sensor.gas_flow
+    name: gas_int
+    unit_time: s
+  - platform: integration
+    source: sensor.water_flow
+    name: water_int
+    unit_time: s
 
 energy_meter:
   daily_energy:
@@ -77,8 +141,71 @@ energy_meter:
     name: Yearly Energy
     cycle: yearly
     price_entity: sensor.energy_price
+
   cost_only_no_id:
     source: sensor.energy2
     name: Energy Cost 2
     price_entity: sensor.energy_price2
     create_utility_meter: no
+  daily_energy_to_grid:
+    unique_id: daily_energy_meter_to_grid
+    source: sensor.energy2
+    name: Daily Energy send to grid
+    cycle: daily
+    price_entity: sensor.energy_price2
+    source_type: to_grid
+    tariffs:
+      - peak
+      - offpeak
+
+  daily_gas:
+    unique_id: daily_gas_meter
+    source: sensor.gas
+    name: Daily Gas
+    cycle: daily
+    price_entity: sensor.gas_price
+    source_type: gas
+    tariffs:
+      - peak
+      - offpeak
+  monthly_gas:
+    source: sensor.gas
+    name: Monthly Gas
+    cycle: monthly
+    price: 5
+    source_type: gas
+    tariffs:
+      - peak
+      - offpeak
+  yearly_gas:
+    source: sensor.gas
+    name: Yearly Gas
+    cycle: yearly
+    price_entity: sensor.gas_price
+    source_type: gas
+
+  daily_water:
+    unique_id: daily_water_meter
+    source: sensor.water
+    name: Daily Water
+    cycle: daily
+    price_entity: sensor.water_price
+    source_type: water
+    tariffs:
+      - peak
+      - offpeak
+  monthly_water:
+    source: sensor.water
+    name: Monthly Water
+    cycle: monthly
+    price: 5
+    source_type: water
+    tariffs:
+      - peak
+      - offpeak
+  yearly_water:
+    source: sensor.water
+    name: Yearly Water
+    cycle: yearly
+    price_entity: sensor.water_price
+    source_type: water

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,4 +1,6 @@
 """Test energy_meter setup process."""
+# Standard libraries
+from unittest.mock import patch
 
 # Third party libraries
 from homeassistant.components.utility_meter.sensor import ATTR_SOURCE_ID
@@ -6,12 +8,14 @@ from homeassistant.setup import async_setup_component
 import pytest
 
 # Project imports
-from custom_components.energy_meter.const import DOMAIN
+from custom_components.energy_meter import get_energy_cost_sensor_adapter
+from custom_components.energy_meter.const import CONF_SOURCE_TYPE, DOMAIN
 from tests.const import (
     CHECK_CREATED_EXPECTED_RESULTS,
     CHECK_UM_SOURCES_EXPECTED_RESULTS,
     TEST_CASES,
 )
+from tests.utils import assert_logger
 
 
 @pytest.mark.parametrize(
@@ -35,7 +39,9 @@ async def test_setup_and_check_created_sensors(hass, config, created_sensors):
     entities = hass.states.async_entity_ids()
     for sensor in created_sensors:
         assert sensor in entities
-    assert len(entities) == len(created_sensors) + 3  # add 2 for sensor.energy & prices
+    assert (
+        len(entities) == len(created_sensors) + 3
+    )  # add constant for sensor.energy & prices
 
 
 @pytest.mark.parametrize(
@@ -59,3 +65,118 @@ async def test_setup_and_utility_meter_sources(hass, config, um_sources):
     for utility_meter, source in um_sources.items():
         assert (state := hass.states.get(utility_meter)) is not None
         assert state.attributes[ATTR_SOURCE_ID] == source
+
+
+@pytest.mark.parametrize(
+    ("em_source_type", "adapter_source_type", "adapter_flow_type"),
+    [
+        (None, "grid", "flow_from"),
+        ("from_grid", "grid", "flow_from"),
+        ("to_grid", "grid", "flow_to"),
+        ("gas", "gas", None),
+        ("water", "water", None),
+    ],
+)
+async def test_valid_source_adapter_resolution(
+    em_source_type,
+    adapter_source_type,
+    adapter_flow_type,
+):
+    """Test resolution of the SourceAdapter."""
+    # define the config and get the adapter
+    conf = {CONF_SOURCE_TYPE: em_source_type} if em_source_type else {}
+    adapter = get_energy_cost_sensor_adapter(conf)
+
+    # assert expected adapter
+    assert adapter is not None
+    assert adapter.source_type == adapter_source_type
+    assert adapter.flow_type == adapter_flow_type
+
+
+async def test_unknown_source_type_adapter_resolution():
+    """Test errors on unknown source_type."""
+    with patch("custom_components.energy_meter._LOGGER") as logger:
+        # define the config and get the adapter
+        conf = {CONF_SOURCE_TYPE: "invalid_value"}
+        adapter = get_energy_cost_sensor_adapter(conf)
+
+        # assert expected adapter
+        assert adapter is None
+        # assert an error is logged
+        assert_logger(logger, "error")
+
+
+async def test_failed_adapter_resolution():
+    """Test errors on failed adapter resolution.
+
+    Ensure an error is raised if builtin AdapterSources change and we
+    cannot find one anymore.
+    """
+    # patch source_type to SourceAdapter mapping
+    with patch(
+        "custom_components.energy_meter.SOURCE_TYPE_TO_SOURCE_ADAPTER",
+        new={
+            "test_source": ("unknown_type", "unknown_flow"),
+        },
+    ), patch("custom_components.energy_meter._LOGGER") as logger:
+        # define the config and get the adapter
+        conf = {CONF_SOURCE_TYPE: "test_source"}
+        adapter = get_energy_cost_sensor_adapter(conf)
+
+        # assert expected adapter
+        assert adapter is None
+        # assert an error is logged
+        assert_logger(logger, "error")
+
+
+async def test_creation_with_invalid_adapter(hass, config):
+    """Test errors creation of meter with invalid adapter."""
+    # define the current energy & price
+    hass.states.async_set("sensor.energy", 100)
+    hass.states.async_set("sensor.price", 2)
+    await hass.async_block_till_done()
+
+    # patch source_type to SourceAdapter mapping
+    with patch(
+        "custom_components.energy_meter.SOURCE_TYPE_TO_SOURCE_ADAPTER",
+        new={
+            "to_grid": ("unknown_type", "unknown_flow"),
+        },
+    ), patch("custom_components.energy_meter._LOGGER") as logger:
+        # setup the integration
+        assert (
+            await async_setup_component(
+                hass,
+                DOMAIN,
+                config
+                | {
+                    DOMAIN: {
+                        "daily_energy": {
+                            "source": "sensor.energy",
+                            "price_entity": "sensor.price",
+                            "tariffs": ["peak", "offpeak"],
+                            "source_type": "to_grid",
+                        },
+                    },
+                },
+            )
+            is True
+        )
+        await hass.async_block_till_done()
+
+        # asserts the created sensors
+        entities = hass.states.async_entity_ids()
+        created_sensors = [
+            "sensor.daily_energy_peak",
+            "sensor.daily_energy_offpeak",
+            "select.daily_energy",
+            # the cost entities should not be created and an error
+            # should be logged
+        ]
+        for sensor in created_sensors:
+            assert sensor in entities
+        assert (
+            len(entities) == len(created_sensors) + 2
+        )  # add constant for sensor.energy & prices
+        # assert an error is logged
+        assert_logger(logger, "error")

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -5,6 +5,9 @@ from unittest.mock import patch
 # Third party libraries
 from homeassistant.setup import async_setup_component
 
+# Project imports
+from tests.utils import assert_logger
+
 
 async def test_direct_setup_exception(hass, config):
     """Test direct setup of the sensor raise an error."""
@@ -16,6 +19,6 @@ async def test_direct_setup_exception(hass, config):
         )
         await hass.async_block_till_done()
         # assert an error is logged
-        logger.error.assert_called()
+        assert_logger(logger, "error")
         # no sensor created
         assert len(hass.states.async_entity_ids()) == 0

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,14 @@
+"""Global helpers for tests."""
+
+# Project imports
+from custom_components.energy_meter.const import DOMAIN
+
+
+def assert_logger(logger_mock, method):
+    """Assert errors match expectations."""
+    # method was called
+    getattr(logger_mock, method).assert_called()
+    # logged message contains the DOMAIN
+    for call in getattr(logger_mock, method).call_args_list:
+        message = call.args[0] % call.args[1:]
+        assert DOMAIN in message


### PR DESCRIPTION
## Content
This PR allow the use of non-grid source type like Gas or Water. It also adds support for "return to grid" energy.
All source type currently supported by the builtin Energy dashboard can now be configured through the new option `source_type`

## Related issues
Fix #32 and #53